### PR TITLE
Fix endless search on windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ function ParentSearch(path, search, options, callback, progress) {
     var result = null
       , locations = []
       , trg = null
+      , root = Path.parse(path).root
       ;
 
     function buildRes(input) {
@@ -77,7 +78,7 @@ function ParentSearch(path, search, options, callback, progress) {
     }
 
     function nextSync (basepath) {
-        if (basepath === "/") { return null; }
+        if (basepath === root) { return null; }
         trg = target(basepath, search);
         if (IsThere(trg.p)) {
             return trg;
@@ -87,7 +88,7 @@ function ParentSearch(path, search, options, callback, progress) {
     }
 
     function next (basepath, cb) {
-        if (basepath === "/") { return cb(null, null); }
+        if (basepath === root) { return cb(null, null); }
         trg = target(basepath, search);
         IsThere(trg.p, function (exists) {
             if (exists) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "directories"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com>",
+  "contributors": [
+     "Jun Gu <2dxgujun@gmail.com> (http://2dxgujun.com)"
+  ],
   "license": "KINDLY",
   "bugs": {
     "url": "https://github.com/IonicaBizau/node-parent-search/issues"


### PR DESCRIPTION
It will enter an endless search on windows, caused by the different root identifier between posix and win32.

Ref: https://github.com/IonicaBizau/node-blah/issues/22
